### PR TITLE
Removes null terminators from Rust strings.

### DIFF
--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -27,6 +27,7 @@ use ::{OclPrm, CommandQueueProperties, PlatformId, PlatformInfo, DeviceId, Devic
     DeviceType, DeviceFpConfig, DeviceMemCacheType, DeviceLocalMemType, DeviceExecCapabilities,
     DevicePartitionProperty, DeviceAffinityDomain, OpenclVersion};
 use error::{Result as OclResult, Error as OclError};
+use util::bytes_to_str;
 // use cl_h;
 
 
@@ -109,9 +110,9 @@ impl PlatformInfoResult {
                         "[NONE]")));
                 }
 
-                let string = match String::from_utf8(result) {
+                let string = match bytes_to_str(result) {
                     Ok(s) => s,
-                    Err(err) => return PlatformInfoResult::Error(Box::new(OclError::from(err))),
+                    Err(err) => return PlatformInfoResult::Error(Box::new(err)),
                 };
 
                 match request {
@@ -514,39 +515,39 @@ impl DeviceInfoResult {
                         DeviceInfoResult::QueueProperties(r)
                     },
                     DeviceInfo::Name => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => DeviceInfoResult::Name(s),
-                            Err(err) => DeviceInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => DeviceInfoResult::Error(Box::new(err)),
                         }
                     },
                     DeviceInfo::Vendor => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => DeviceInfoResult::Vendor(s),
-                            Err(err) => DeviceInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => DeviceInfoResult::Error(Box::new(err)),
                         }
                     },
                     DeviceInfo::DriverVersion => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => DeviceInfoResult::DriverVersion(s),
-                            Err(err) => DeviceInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => DeviceInfoResult::Error(Box::new(err)),
                         }
                     },
                     DeviceInfo::Profile => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => DeviceInfoResult::Profile(s),
-                            Err(err) => DeviceInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => DeviceInfoResult::Error(Box::new(err)),
                         }
                     },
                     DeviceInfo::Version => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => DeviceInfoResult::Version(s),
-                            Err(err) => DeviceInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => DeviceInfoResult::Error(Box::new(err)),
                         }
                     },
                     DeviceInfo::Extensions => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => DeviceInfoResult::Extensions(s),
-                            Err(err) => DeviceInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => DeviceInfoResult::Error(Box::new(err)),
                         }
                     },
                     DeviceInfo::Platform => {
@@ -598,9 +599,9 @@ impl DeviceInfoResult {
                         DeviceInfoResult::NativeVectorWidthHalf(r)
                     },
                     DeviceInfo::OpenclCVersion => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => DeviceInfoResult::OpenclCVersion(s),
-                            Err(err) => DeviceInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => DeviceInfoResult::Error(Box::new(err)),
                         }
                     },
                     DeviceInfo::LinkerAvailable => {
@@ -608,9 +609,9 @@ impl DeviceInfoResult {
                         DeviceInfoResult::LinkerAvailable(r != 0)
                     },
                     DeviceInfo::BuiltInKernels => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => DeviceInfoResult::BuiltInKernels(s),
-                            Err(err) => DeviceInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => DeviceInfoResult::Error(Box::new(err)),
                         }
                     },
                     DeviceInfo::ImageMaxBufferSize => {
@@ -1439,9 +1440,9 @@ impl ProgramInfoResult {
                         )
                     },
                     ProgramInfo::Source => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => ProgramInfoResult::Source(s),
-                            Err(err) => ProgramInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => ProgramInfoResult::Error(Box::new(err)),
                         }
                     },
                     ProgramInfo::BinarySizes => { ProgramInfoResult::BinarySizes(
@@ -1456,9 +1457,9 @@ impl ProgramInfoResult {
                         ProgramInfoResult::NumKernels(r)
                     },
                     ProgramInfo::KernelNames => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => ProgramInfoResult::KernelNames(s),
-                            Err(err) => ProgramInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => ProgramInfoResult::Error(Box::new(err)),
                         }
                     },
                     // _ => ProgramInfoResult::TemporaryPlaceholderVariant(result),
@@ -1548,15 +1549,15 @@ impl ProgramBuildInfoResult {
                         }
                     },
                     ProgramBuildInfo::BuildOptions => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => ProgramBuildInfoResult::BuildOptions(s),
-                            Err(err) => ProgramBuildInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => ProgramBuildInfoResult::Error(Box::new(err)),
                         }
                     },
                     ProgramBuildInfo::BuildLog => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => ProgramBuildInfoResult::BuildLog(s),
-                            Err(err) => ProgramBuildInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => ProgramBuildInfoResult::Error(Box::new(err)),
                         }
                     },
                     ProgramBuildInfo::BinaryType => {
@@ -1634,9 +1635,9 @@ impl KernelInfoResult {
                 }
                 match request {
                     KernelInfo::FunctionName => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => KernelInfoResult::FunctionName(s),
-                            Err(err) => KernelInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => KernelInfoResult::Error(Box::new(err)),
                         }
                     },
                     KernelInfo::NumArgs => {
@@ -1656,9 +1657,9 @@ impl KernelInfoResult {
                         KernelInfoResult::Program(unsafe { Program::from_copied_ptr(ptr) })
                     },
                     KernelInfo::Attributes => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => KernelInfoResult::Attributes(s),
-                            Err(err) => KernelInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => KernelInfoResult::Error(Box::new(err)),
                         }
                     },
                 }
@@ -1751,9 +1752,9 @@ impl KernelArgInfoResult {
                         }
                     },
                     KernelArgInfo::TypeName => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => KernelArgInfoResult::TypeName(s),
-                            Err(err) => KernelArgInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => KernelArgInfoResult::Error(Box::new(err)),
                         }
                     },
                     KernelArgInfo::TypeQualifier => {
@@ -1761,9 +1762,9 @@ impl KernelArgInfoResult {
                         KernelArgInfoResult::TypeQualifier(r)
                     },
                     KernelArgInfo::Name => {
-                        match String::from_utf8(result) {
+                        match bytes_to_str(result) {
                             Ok(s) => KernelArgInfoResult::Name(s),
-                            Err(err) => KernelArgInfoResult::Error(Box::new(OclError::from(err))),
+                            Err(err) => KernelArgInfoResult::Error(Box::new(err)),
                         }
                     },
                 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -336,6 +336,15 @@ pub fn shuffle<T: OclScl>(vec: &mut [T]) {
     }
 }
 
+/// Converts a null-terminated byte slice to a string.
+pub fn bytes_to_str(mut bytes: Vec<u8>) -> OclResult<String> {
+    if bytes.pop() == Some(0u8) {
+        String::from_utf8(bytes).map_err(OclError::from)
+    } else {
+        Err(OclError::from("string not null terminated: this is probably a driver bug"))
+    }
+}
+
 
 // /// Converts a length in `T` to a size in bytes.
 // #[inline]


### PR DESCRIPTION
Refer https://github.com/cogciprocate/ocl/issues/48.