### PR TITLE
Add nvidia specific error code -9999

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -582,6 +582,7 @@ enum_from_primitive! {
         CL_INVALID_PIPE_SIZE                            = -69,
         CL_INVALID_DEVICE_QUEUE                         = -70,
         CL_PLATFORM_NOT_FOUND_KHR                       = -1001,
+        CL_NV_INVALID_MEM_ACCESS                        = -9999,
     }
 }
 


### PR DESCRIPTION
This error occurs on nvidia hardware when using large amounts of memory.  Currently ocl-core panics on this error. I added this error code into Status enum, so it can be handled like any other error.