### PR TITLE
Fixed compilation error with Mesa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ opencl_version_1_1 = ["cl-sys/opencl_version_1_1"]
 opencl_version_1_2 = ["cl-sys/opencl_version_1_2"]
 opencl_version_2_0 = ["cl-sys/opencl_version_2_0"]
 opencl_version_2_1 = ["cl-sys/opencl_version_2_1"]
+opencl_vendor_mesa = ["cl-sys/opencl_vendor_mesa"]
 
 default = ["ocl-core-vector", "rand", "opencl_version_1_1", "opencl_version_1_2"]
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -17,13 +17,11 @@ use std::fmt::Debug;
 use libc::{size_t, c_void};
 use num::FromPrimitive;
 
-use ffi::{cl_GLuint, cl_GLint, cl_GLenum, cl_gl_context_info,};
-use ffi::{clCreateFromGLBuffer, clCreateFromGLRenderbuffer, clCreateFromGLTexture,
-    clCreateFromGLTexture2D, clCreateFromGLTexture3D};
-
 #[cfg(not(feature="opencl_vendor_mesa"))]
-use ffi::{
-    clEnqueueAcquireGLObjects,
+use ffi::{cl_GLuint, cl_GLint, cl_GLenum, cl_gl_context_info,};
+#[cfg(not(feature="opencl_vendor_mesa"))]
+use ffi::{clCreateFromGLBuffer, clCreateFromGLRenderbuffer, clCreateFromGLTexture,
+    clCreateFromGLTexture2D, clCreateFromGLTexture3D, clEnqueueAcquireGLObjects,
     clEnqueueReleaseGLObjects};
 
 use ffi::{self, cl_bool, cl_int, cl_uint, cl_platform_id, cl_device_id, cl_device_type,
@@ -36,8 +34,8 @@ use ffi::{self, cl_bool, cl_int, cl_uint, cl_platform_id, cl_device_id, cl_devic
 
 use error::{Error as OclError, ErrorKind as OclErrorKind, Result as OclResult, ChainErr};
 
-use ::{OclPrm, PlatformId, DeviceId, Context, ContextProperties, ContextInfo, GlContextInfo,
-    ContextInfoResult, GlContextInfoResult, MemFlags, CommandQueue, Mem, MemObjectType, Program,
+use ::{OclPrm, PlatformId, DeviceId, Context, ContextProperties, ContextInfo,
+    ContextInfoResult, MemFlags, CommandQueue, Mem, MemObjectType, Program,
     Kernel, ClNullEventPtr, Sampler, KernelArg, DeviceType, ImageFormat, ImageDescriptor,
     CommandExecutionStatus, AddressingMode, FilterMode, PlatformInfo, PlatformInfoResult,
     DeviceInfo, DeviceInfoResult, CommandQueueInfo, CommandQueueInfoResult, MemInfo, MemInfoResult,
@@ -50,6 +48,8 @@ use ::{OclPrm, PlatformId, DeviceId, Context, ContextProperties, ContextInfo, Gl
     BufferCreateType, OpenclVersion, ClVersions, Status, CommandQueueProperties, MemMap, AsMem,
     MemCmdRw, MemCmdAll, Event, ImageFormatParseResult};
 
+#[cfg(not(feature="opencl_vendor_mesa"))]
+use ::{GlContextInfo, GlContextInfoResult};
 
 // [TODO]: Do proper auto-detection of available OpenGL context type.
 #[cfg(target_os="macos")]
@@ -798,6 +798,7 @@ pub fn get_context_platform<C>(context: C) -> OclResult<Option<PlatformId>>
 /// with how libraries are loaded into memory. There may alternatively just be
 /// a simple mistake somewhere.
 ///
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub fn get_gl_context_info_khr(properties: &ContextProperties, request: GlContextInfo)
         -> GlContextInfoResult
 {
@@ -993,6 +994,7 @@ pub unsafe fn create_buffer<C, T>(
 
 /// [UNTESTED]
 /// Return a buffer pointer from a `OpenGL` buffer object.
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub unsafe fn create_from_gl_buffer<C>(
             context: C,
             gl_object: cl_GLuint,
@@ -1017,6 +1019,7 @@ pub unsafe fn create_from_gl_buffer<C>(
 
 /// [UNTESTED]
 /// Return a renderbuffer pointer from a `OpenGL` renderbuffer object.
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub unsafe fn create_from_gl_renderbuffer<C>(
             context: C,
             renderbuffer: cl_GLuint,
@@ -1045,6 +1048,7 @@ pub unsafe fn create_from_gl_renderbuffer<C>(
 /// [TODO]: If version is < 1.2, automatically use older versions.
 ///
 /// [Version Controlled: OpenCL 1.2+] See module docs for more info.
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub unsafe fn create_from_gl_texture<C>(
             context: C,
             texture_target: cl_GLenum,
@@ -1095,6 +1099,7 @@ pub unsafe fn create_from_gl_texture<C>(
 
 /// [UNTESTED] [DEPRICATED]
 /// Return a texture2D pointer from a `OpenGL` texture2D object.
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub unsafe fn create_from_gl_texture_2d<C>(
             context: C,
             texture_target: cl_GLenum,
@@ -1123,6 +1128,7 @@ pub unsafe fn create_from_gl_texture_2d<C>(
 
 /// [UNTESTED] [DEPRICATED]
 /// Return a texture3D pointer from a `OpenGL` texture3D object.
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub unsafe fn create_from_gl_texture_3d<C>(
             context: C,
             texture_target: cl_GLenum,
@@ -2414,6 +2420,7 @@ pub unsafe fn enqueue_write_buffer_rect<T, M, En, Ewl>(
 /// ## Pattern (from [SDK Docs](https://www.khronos.org/registry/cl/sdk/1.2/docs/man/xhtml/clEnqueueFillBuffer.html))
 ///
 /// [Version Controlled: OpenCL 1.2+] See module docs for more info.
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub fn enqueue_fill_buffer<T, M, En, Ewl>(
             command_queue: &CommandQueue,
             buffer: M,

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -19,7 +19,11 @@ use num::FromPrimitive;
 
 use ffi::{cl_GLuint, cl_GLint, cl_GLenum, cl_gl_context_info,};
 use ffi::{clCreateFromGLBuffer, clCreateFromGLRenderbuffer, clCreateFromGLTexture,
-    clCreateFromGLTexture2D, clCreateFromGLTexture3D, clEnqueueAcquireGLObjects,
+    clCreateFromGLTexture2D, clCreateFromGLTexture3D};
+
+#[cfg(not(feature="opencl_vendor_mesa"))]
+use ffi::{
+    clEnqueueAcquireGLObjects,
     clEnqueueReleaseGLObjects};
 
 use ffi::{self, cl_bool, cl_int, cl_uint, cl_platform_id, cl_device_id, cl_device_type,
@@ -2531,6 +2535,7 @@ pub fn enqueue_copy_buffer_rect<T, M, En, Ewl>(
 /// [UNTESTED]
 /// Enqueue acquire OpenCL memory object that has been created from an `OpenGL` object.
 #[deprecated(since="0.6.0", note="Use `::enqueue_acquire_gl_objects` instead.")]
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub fn enqueue_acquire_gl_buffer<En, Ewl>(
             command_queue: &CommandQueue,
             buffer: &Mem,
@@ -2559,6 +2564,7 @@ pub fn enqueue_acquire_gl_buffer<En, Ewl>(
 /// To create a slice from a single `Mem` reference without any cost, use
 /// something like: `unsafe { ::std::slice::from_raw_parts(&core_mem, 1) };`.
 ///
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub fn enqueue_acquire_gl_objects<En, Ewl>(
             command_queue: &CommandQueue,
             buffers: &[Mem],
@@ -2585,6 +2591,7 @@ pub fn enqueue_acquire_gl_objects<En, Ewl>(
 /// [UNTESTED]
 /// Enqueue release a single OpenCL memory object that has been created from an `OpenGL` object.
 #[deprecated(since="0.6.0", note="Use `::enqueue_release_gl_objects` instead.")]
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub fn enqueue_release_gl_buffer<En, Ewl>(
             command_queue: &CommandQueue,
             buffer: &Mem,
@@ -2613,6 +2620,7 @@ pub fn enqueue_release_gl_buffer<En, Ewl>(
 /// To create a slice from a single `Mem` reference without any cost, use
 /// something like: `unsafe { ::std::slice::from_raw_parts(&core_mem, 1) };`.
 ///
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub fn enqueue_release_gl_objects<En, Ewl>(
             command_queue: &CommandQueue,
             buffers: &[Mem],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub use self::types::enums::{EmptyInfoResult, KernelArg, PlatformInfoResult, Dev
 
 pub use self::functions::{get_platform_ids, get_platform_info, get_device_ids, get_device_info,
     create_sub_devices, retain_device, release_device, create_context, create_context_from_type,
-    retain_context, release_context, get_context_info, get_gl_context_info_khr,
+    retain_context, release_context, get_context_info,
     create_command_queue, retain_command_queue, release_command_queue, get_command_queue_info,
     create_buffer, create_sub_buffer, create_image, retain_mem_object, release_mem_object,
     get_supported_image_formats, get_mem_object_info, get_image_info,
@@ -146,8 +146,6 @@ pub use self::functions::{get_platform_ids, get_platform_info, get_device_ids, g
     get_event_info, create_user_event, retain_event, release_event, set_user_event_status,
     set_event_callback, get_event_profiling_info, flush, finish, enqueue_read_buffer,
     enqueue_read_buffer_rect, enqueue_write_buffer, enqueue_write_buffer_rect, enqueue_copy_buffer,
-    create_from_gl_buffer, create_from_gl_renderbuffer, create_from_gl_texture,
-    create_from_gl_texture_2d, create_from_gl_texture_3d, enqueue_fill_buffer,
     enqueue_copy_buffer_rect,
     enqueue_read_image, enqueue_write_image, enqueue_fill_image, enqueue_copy_image,
     enqueue_copy_image_to_buffer, enqueue_copy_buffer_to_image, enqueue_map_buffer,
@@ -160,6 +158,9 @@ pub use self::functions::{get_platform_ids, get_platform_info, get_device_ids, g
 
 #[cfg(not(feature="opencl_vendor_mesa"))]
 pub use self::functions::{
+    get_gl_context_info_khr,
+    create_from_gl_buffer, create_from_gl_renderbuffer, create_from_gl_texture,
+    create_from_gl_texture_2d, create_from_gl_texture_3d, enqueue_fill_buffer,
     enqueue_acquire_gl_objects, enqueue_release_gl_objects};
 
 #[allow(deprecated)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ pub use self::functions::{get_platform_ids, get_platform_info, get_device_ids, g
     enqueue_read_buffer_rect, enqueue_write_buffer, enqueue_write_buffer_rect, enqueue_copy_buffer,
     create_from_gl_buffer, create_from_gl_renderbuffer, create_from_gl_texture,
     create_from_gl_texture_2d, create_from_gl_texture_3d, enqueue_fill_buffer,
-    enqueue_copy_buffer_rect, enqueue_acquire_gl_objects, enqueue_release_gl_objects,
+    enqueue_copy_buffer_rect,
     enqueue_read_image, enqueue_write_image, enqueue_fill_image, enqueue_copy_image,
     enqueue_copy_image_to_buffer, enqueue_copy_buffer_to_image, enqueue_map_buffer,
     enqueue_map_image, enqueue_unmap_mem_object, enqueue_migrate_mem_objects, enqueue_kernel,
@@ -158,7 +158,12 @@ pub use self::functions::{get_platform_ids, get_platform_info, get_device_ids, g
     default_device_type, device_versions, event_is_complete, _dummy_event_callback,
     _complete_user_event, get_context_platform};
 
+#[cfg(not(feature="opencl_vendor_mesa"))]
+pub use self::functions::{
+    enqueue_acquire_gl_objects, enqueue_release_gl_objects};
+
 #[allow(deprecated)]
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub use self::functions::{enqueue_acquire_gl_buffer, enqueue_release_gl_buffer};
 
 pub use traits::{OclPrm, OclNum, OclScl};


### PR DESCRIPTION
Excluded functions related to context sharing OpenGL. 

Currently Mesa does not support context sharing with OpenGL. The related functions are missing from the Mesa library and will cause linker errors if referenced.
    
Constants and structs related to the context sharing with OpenGL still included. Reasoning: Easier to develop libraries / applications that in some configurations require OpenGL context sharing. With the constants and structs included, there is potentially less functionality that the library / application needs to exclude with Mesa.